### PR TITLE
Amy/20241203/prompt caching

### DIFF
--- a/modules/generators.py
+++ b/modules/generators.py
@@ -25,7 +25,6 @@ async def _claude_legacy_factory(
 
     middleman_settings_copy = copy.deepcopy(middleman_settings)
     middleman_settings_copy.stop = [f"</{tool}" for tool in agent.toolkit_dict]
-    messages = agent.state.next_step["args"]["messages"]
     wrapped_messages = [
         {
             "role": "system",


### PR DESCRIPTION
Features
- trim messages in batches of 10 to increase prompt caching hit rates
- edited generator to allow the newest version of 3.5-sonnet to use prompt caching. We always set the last 2 user turns in a long conversations as the cache break points to optimize hit rate. Reference: https://github.com/anthropics/anthropic-cookbook/blob/main/misc/prompt_caching.ipynb