### PR TITLE
Add action logs for bash, python, and scoring

### DIFF
--- a/modules/tools.py
+++ b/modules/tools.py
@@ -11,6 +11,10 @@ from templates import default_timeout
 
 async def run_python(_state: State, code: str) -> str:
     timeout = _state.timeout
+    await hooks.action({
+        "type": "run_python",
+        "args": {"code": code},
+    })
     output = await actions.run_python(code, timeout=timeout)
     return output
 
@@ -32,6 +36,10 @@ run_python_object = {
 
 
 async def score_fn(_state: State) -> str:
+    await hooks.action({
+        "type": "score",
+        "args": {},
+    })
     output = (await hooks.score()).model_dump()
     if output["score"] is None:
         del output["score"]
@@ -54,6 +62,10 @@ score_fn_object = {
 
 
 async def score_log_fn(_state: State) -> str:
+    await hooks.action({
+        "type": "score_log",
+        "args": {},
+    })
     output = await hooks.scoreLog()
     return json.dumps([entry.model_dump() for entry in output])
 
@@ -139,6 +151,10 @@ async def run_bash_state(
     timeout = _state.timeout
     if timeout_override is not None:
         timeout = timeout_override
+    await hooks.action({
+        "type": "run_bash",
+        "args": {"command": command},
+    })
     output = await actions.run_bash(command, timeout)
     o = json.loads(output)
     output_string = o["stdout"] + "\n" + o["stderr"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "modular-public"
-version = "1.1.7"
+version = "1.2.0a1"
 description = ""
 authors = ["METR <team@metr.org>"]
 readme = "README.md"

--- a/tests/modules/test_tools.py
+++ b/tests/modules/test_tools.py
@@ -33,6 +33,7 @@ async def test_score_fn(mocker: MockerFixture):
         ),
     )
     mocker.patch("pyhooks.Hooks.score", autospec=True, return_value=expected_output)
+    mocker.patch("pyhooks.Hooks.action", autospec=True, return_value=mocker.AsyncMock()())
 
     output = await tools.score_fn(base.State(task_string="test task"))
 
@@ -77,6 +78,7 @@ async def test_score_feedback(
     )
     mocker.patch("pyhooks.Hooks.log", autospec=True)
     mocker.patch("pyhooks.Hooks.log_with_attributes", autospec=True)
+    mocker.patch("pyhooks.Hooks.action", autospec=True, return_value=mocker.AsyncMock()())
     generate_mock = mocker.patch(
         "pyhooks.Hooks.generate",
         autospec=True,
@@ -199,6 +201,7 @@ async def test_score_log_fn(mocker: MockerFixture):
         )
     ]
     mocker.patch("pyhooks.Hooks.scoreLog", autospec=True, return_value=expected_output)
+    mocker.patch("pyhooks.Hooks.action", autospec=True, return_value=mocker.AsyncMock()())
 
     output = await tools.score_log_fn(base.State(task_string="test task"))
 

--- a/tests/modules/test_tools.py
+++ b/tests/modules/test_tools.py
@@ -33,12 +33,16 @@ async def test_score_fn(mocker: MockerFixture):
         ),
     )
     mocker.patch("pyhooks.Hooks.score", autospec=True, return_value=expected_output)
-    mocker.patch("pyhooks.Hooks.action", autospec=True, return_value=mocker.AsyncMock()())
+    action_mock = mocker.patch("pyhooks.Hooks.action", autospec=True, return_value=mocker.AsyncMock()())
 
     output = await tools.score_fn(base.State(task_string="test task"))
 
     assert isinstance(output, str)
     assert json.loads(output) == expected_output.model_dump()
+    action_mock.assert_called_once()
+    assert isinstance(action_mock.call_args.args[1], dict)
+    assert action_mock.call_args.args[1]["type"] == "score"
+    assert isinstance(action_mock.call_args.args[1]["args"], dict)
 
 
 @pytest.mark.asyncio
@@ -78,7 +82,7 @@ async def test_score_feedback(
     )
     mocker.patch("pyhooks.Hooks.log", autospec=True)
     mocker.patch("pyhooks.Hooks.log_with_attributes", autospec=True)
-    mocker.patch("pyhooks.Hooks.action", autospec=True, return_value=mocker.AsyncMock()())
+    action_mock = mocker.patch("pyhooks.Hooks.action", autospec=True, return_value=mocker.AsyncMock()())
     generate_mock = mocker.patch(
         "pyhooks.Hooks.generate",
         autospec=True,
@@ -124,6 +128,10 @@ async def test_score_feedback(
     assert score_mock.call_count == 1, agent.state.nodes[
         agent.state.last_node_id
     ].message
+    action_mock.assert_called_once()
+    assert isinstance(action_mock.call_args.args[1], dict)
+    assert action_mock.call_args.args[1]["type"] == "score"
+    assert isinstance(action_mock.call_args.args[1]["args"], dict)
     expected_content = json.dumps(score_result.model_dump())
     if expected_output_file is not None:
         expected_content += f"\n\n[Note: the above tool output has been saved to {expected_output_file}]"
@@ -201,9 +209,51 @@ async def test_score_log_fn(mocker: MockerFixture):
         )
     ]
     mocker.patch("pyhooks.Hooks.scoreLog", autospec=True, return_value=expected_output)
-    mocker.patch("pyhooks.Hooks.action", autospec=True, return_value=mocker.AsyncMock()())
+    action_mock = mocker.patch("pyhooks.Hooks.action", autospec=True, return_value=mocker.AsyncMock()())
 
     output = await tools.score_log_fn(base.State(task_string="test task"))
 
     assert isinstance(output, str)
     assert json.loads(output) == [x.model_dump() for x in expected_output]
+    action_mock.assert_called_once()
+    assert isinstance(action_mock.call_args.args[1], dict)
+    assert action_mock.call_args.args[1]["type"] == "score_log"
+    assert isinstance(action_mock.call_args.args[1]["args"], dict)
+
+
+@pytest.mark.asyncio
+async def test_run_python(mocker: MockerFixture):
+    expected_output = "test output"
+    mocker.patch("base.actions.run_python", autospec=True, return_value=expected_output)
+    action_mock = mocker.patch("pyhooks.Hooks.action", autospec=True, return_value=mocker.AsyncMock()())
+
+    test_code = "test code"
+    output = await tools.run_python(base.State(task_string="test task", timeout=5), test_code)
+
+    assert output == expected_output
+    action_mock.assert_called_once()
+    assert isinstance(action_mock.call_args.args[1], dict)
+    assert action_mock.call_args.args[1]["type"] == "run_python"
+    assert isinstance(action_mock.call_args.args[1]["args"], dict)
+    assert action_mock.call_args.args[1]["args"]["code"] == test_code
+
+
+@pytest.mark.asyncio
+async def test_run_bash_state(mocker: MockerFixture):
+    expected_output = json.dumps({
+        "stdout": "test stdout",
+        "stderr": "test stderr",
+        "status": 0
+    })
+    mocker.patch("base.actions.run_bash", autospec=True, return_value=expected_output)
+    action_mock = mocker.patch("pyhooks.Hooks.action", autospec=True, return_value=mocker.AsyncMock()())
+
+    test_command = "test command"
+    output = await tools.run_bash_state(base.State(task_string="test task", timeout=5), test_command)
+
+    assert output == "test stdout\ntest stderr\nExit code: 0"
+    action_mock.assert_called_once()
+    assert isinstance(action_mock.call_args.args[1], dict)
+    assert action_mock.call_args.args[1]["type"] == "run_bash"
+    assert isinstance(action_mock.call_args.args[1]["args"], dict)
+    assert action_mock.call_args.args[1]["args"]["command"] == test_command


### PR DESCRIPTION
Possibly controversial point: does not record submitting as an action. This matches [the treatment in flock](https://github.com/poking-agents/temp-flock/pull/3/files).

[test run](https://mp4-server.koi-moth.ts.net/run/#224184/su,uq), [actions in the db](https://mp4-server.koi-moth.ts.net/runs/?sql=SELECT%0A++te.index%2C%0A++te.type%2C%0A++te.%22calledAt%22%2C%0A++te.content%0AFROM+trace_entries_t+te%0AWHERE+te.%22runId%22+%3D+224184+and+te.%22type%22+%3D+%27action%27%0AORDER+BY+te.%22calledAt%22+ASC%3B)

Closes #32 