### PR TITLE
fix set timeout to handle errors appropriately

### DIFF
--- a/modules/tools.py
+++ b/modules/tools.py
@@ -11,10 +11,12 @@ from templates import default_timeout
 
 async def run_python(_state: State, code: str) -> str:
     timeout = _state.timeout
-    await hooks.action({
-        "type": "run_python",
-        "args": {"code": code},
-    })
+    await hooks.action(
+        {
+            "type": "run_python",
+            "args": {"code": code},
+        }
+    )
     output = await actions.run_python(code, timeout=timeout)
     return output
 
@@ -36,10 +38,12 @@ run_python_object = {
 
 
 async def score_fn(_state: State) -> str:
-    await hooks.action({
-        "type": "score",
-        "args": {},
-    })
+    await hooks.action(
+        {
+            "type": "score",
+            "args": {},
+        }
+    )
     output = (await hooks.score()).model_dump()
     if output["score"] is None:
         del output["score"]
@@ -62,10 +66,12 @@ score_fn_object = {
 
 
 async def score_log_fn(_state: State) -> str:
-    await hooks.action({
-        "type": "score_log",
-        "args": {},
-    })
+    await hooks.action(
+        {
+            "type": "score_log",
+            "args": {},
+        }
+    )
     output = await hooks.scoreLog()
     return json.dumps([entry.model_dump() for entry in output])
 
@@ -151,10 +157,12 @@ async def run_bash_state(
     timeout = _state.timeout
     if timeout_override is not None:
         timeout = timeout_override
-    await hooks.action({
-        "type": "run_bash",
-        "args": {"command": command},
-    })
+    await hooks.action(
+        {
+            "type": "run_bash",
+            "args": {"command": command},
+        }
+    )
     output = await actions.run_bash(command, timeout)
     o = json.loads(output)
     output_string = o["stdout"] + "\n" + o["stderr"]
@@ -179,7 +187,7 @@ run_bash_state_object = {
 }
 
 
-async def set_timeout(_state: State, timeout: str | int) -> str:
+async def set_timeout(_state: State, timeout: str | int | Any) -> str:
     original_timeout = _state.timeout
     max_timeout = (25 - 1) * 60  # from pyhooks
     if isinstance(timeout, str):
@@ -197,6 +205,8 @@ async def set_timeout(_state: State, timeout: str | int) -> str:
     elif isinstance(timeout, int):
         _state.timeout = timeout
         return f"Timeout changed from {original_timeout} to {timeout} seconds."
+    else:
+        return f"Error: Timeout must be an integer. Timeout remains at {original_timeout} seconds."
 
 
 set_timeout_object = {


### PR DESCRIPTION
Sorry about the code formatting change that got mixed into this.
The fix is only for the set_timeout function. 

Failed run example: https://mp4-server.koi-moth.ts.net/run/#212714/ss
This failure is caused by set_timeout returning None when the type of `timeout` is neither a string or an int. We now explicitly handle this case.