### PR TITLE
Fix GitHub workflow

### DIFF
--- a/.github/workflows/pr-and-main.yaml
+++ b/.github/workflows/pr-and-main.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
 
       - uses: actions/setup-python@v5
         with:
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
 
       - uses: actions/setup-python@v5
         with:
@@ -58,7 +58,7 @@ jobs:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
On January 5, the Poetry maintainers released v2.0.0, which apparently breaks our workflow. This change pins the Poetry version to stop that happening.