### PR TITLE
fix bad function call that caused lab API 400s

### DIFF
--- a/modules/actors.py
+++ b/modules/actors.py
@@ -17,8 +17,9 @@ async def get_result_message_simple(agent: Agent) -> Optional[Message]:
     output = ""
     if tool_name not in agent.toolkit_dict:
         return Message(
-            role="user",
+            role="function",
             content=reject_command_prompt,
+            name=tool_name,
             function_call=None,
         )
 
@@ -35,8 +36,9 @@ async def get_result_message_simple(agent: Agent) -> Optional[Message]:
     if not tool_params:
         if agent_args:
             return Message(
-                role="user",
+                role="function",
                 content=reject_arguments_prompt,
+                name=tool_name,
                 function_call=None,
             )
         return Message(
@@ -52,15 +54,17 @@ async def get_result_message_simple(agent: Agent) -> Optional[Message]:
             output = await tool_fn(agent.state, **agent_args)
         except TypeError:
             return Message(
-                role="user",
+                role="function",
                 content=reject_arguments_prompt,
+                name=tool_name,
                 function_call=None,
-            )
+        )
     elif len(required_args) != 1:
         # tell agent the command failed
         return Message(
-            role="user",
+            role="function",
             content=reject_arguments_prompt,
+            name=tool_name,
             function_call=None,
         )
     else:

--- a/tests/modules/test_actors.py
+++ b/tests/modules/test_actors.py
@@ -53,7 +53,8 @@ def fixture_tool_object(request: pytest.FixtureRequest):
             TOOL_OBJECT_NO_ARGS,
             {"name": "score", "arguments": "Extra stuff"},
             RESPONSE_REJECT := base.Message(
-                role="user",
+                role="function",
+                name="score",
                 content=templates.reject_arguments_prompt,
                 function_call=None,
             ),


### PR DESCRIPTION
- We saw lab api 400s like this run: https://mp4-server.koi-moth.ts.net/run/#231315/ss
- The fix is to have the error message be a function turn as opposed to a user turn
- Here's an agent run with the fix branching from the agent state before the error in the previous run: https://mp4-server.koi-moth.ts.net/run/#244894/e=8532127042727147,sg,uq
- Here's another branch from the same place but using an anthropic model: https://mp4-server.koi-moth.ts.net/run/#244895/uq
