### PR TITLE
Fix usage message, state trimming causing fncall role mismatch

### DIFF
--- a/modules/prompters.py
+++ b/modules/prompters.py
@@ -96,7 +96,7 @@ def trim_message_list(messages: List[Message], target_tok_length: int) -> List[M
         # the last message pre-trim cannot have a function call because the
         # corresponding function output will be trimmed and the OpenAI API will
         # complain about the mismatch
-        head.pop()
+        head_messages_to_use.pop()
     for msg in head_messages_to_use:
         tokens_to_use -= len(enc.encode(msg.content, disallowed_special=()))
         tokens_to_use -= len(

--- a/modules/prompters.py
+++ b/modules/prompters.py
@@ -166,14 +166,16 @@ async def _context_and_usage_aware(agent: Agent) -> None:
 
     if token_usage_fraction > time_usage_fraction:
         usage_fraction = token_usage_fraction
-        usage_type = "tokens"
+        usage_value = agent.state.token_usage
+        usage_unit = "tokens"
         usage_limit = agent.state.token_limit
     else:
         usage_fraction = time_usage_fraction
-        usage_type = "time"
+        usage_value = agent.state.time_usage
+        usage_unit = "seconds"
         usage_limit = agent.state.time_limit
 
-    usage_message = f"So far in this attempt at the task, you have used {usage_fraction} {usage_type}, out of the total limit of {usage_limit}."
+    usage_message = f"So far in this attempt at the task, you have used {usage_value} {usage_unit}, out of the total limit of {usage_limit} {usage_unit}."
     if usage_fraction > (9 / 10):
         usage_message += " You should submit a final answer soon."
     elif usage_fraction > (3 / 4):


### PR DESCRIPTION
Closes #41 

Also fixes an issue where state trimming may cause a function message mismatch: If there is a function call that is not followed by a function message, or a function message that is not preceded by a function call, the OpenAI API will complain. But this situation was arising sometimes during state trimming. This PR fixes that.